### PR TITLE
sync-cluster-resources before FlyteAdmin starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Flyte
 
-Flyte is a K8s-native, multi-tenant, distributed orchestration engine that manages highly scalable compute workflows. Extensibility is provided by Flyte plugins and K8s operators, including executors for Spark, Hive, AWS Batch, in addition to raw K8s compute.  Flyte can orchestrate arbitrary containers at scale, providing feature fanout, automatic task parallelization, strongly-typed paramerter passing, automatic cluster scale up and scale down, cluster fail-over, and fine-grained programmatic control over retry policies, error handling, and notifications.  
+Flyte is a K8s-native, multi-tenant, distributed orchestration engine that manages highly scalable compute workflows.
+
+Extensibility is provided by Flyte plugins and K8s operators, including executors for Spark, Hive, AWS Batch, in addition to raw K8s compute.  Flyte can orchestrate arbitrary containers at scale, providing feature fanout, automatic task parallelization, strongly-typed paramerter passing, automatic cluster scale up and scale down, cluster fail-over, and fine-grained programmatic control over retry policies, error handling, and notifications.  
 
 See docs at https://lyft.github.io/flyte/

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -1078,8 +1078,26 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      - command:
+        - flyteadmin
+        - --logtostderr
+        - --config
+        - /etc/flyte/config/flyteadmin_config.yaml
+        - clusterresource
+        - sync
+        image: docker.io/lyft/flyteadmin:v0.1.1
+        imagePullPolicy: IfNotPresent
+        name: sync-cluster-resources
+        volumeMounts:
+        - mountPath: /etc/flyte/clusterresource/templates
+          name: resource-templates
+        - mountPath: /etc/flyte/config
+          name: config-volume
       serviceAccountName: flyteadmin
       volumes:
+      - configMap:
+          name: clusterresource-template-dgc9fcm2kh
+        name: resource-templates
       - emptyDir: {}
         name: shared-data
       - configMap:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -739,8 +739,26 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
+      - command:
+        - flyteadmin
+        - --logtostderr
+        - --config
+        - /etc/flyte/config/flyteadmin_config.yaml
+        - clusterresource
+        - sync
+        image: docker.io/lyft/flyteadmin:v0.1.1
+        imagePullPolicy: IfNotPresent
+        name: sync-cluster-resources
+        volumeMounts:
+        - mountPath: /etc/flyte/clusterresource/templates
+          name: resource-templates
+        - mountPath: /etc/flyte/config
+          name: config-volume
       serviceAccountName: flyteadmin
       volumes:
+      - configMap:
+          name: clusterresource-template-dgc9fcm2kh
+        name: resource-templates
       - emptyDir: {}
         name: shared-data
       - configMap:

--- a/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   template:
     spec:
+      volumes:
+      - name: resource-templates 
+        configMap:
+          name: clusterresource-template 
       initContainers:
       - name: check-db-ready
         image: postgres:10.1
@@ -26,6 +30,15 @@ spec:
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml",
                   "migrate", "seed-projects", "flytesnacks", "flytetester"]
         volumeMounts:
+        - name: config-volume
+          mountPath: /etc/flyte/config
+      - name: sync-cluster-resources
+        image: docker.io/lyft/flyteadmin:v0.1.1
+        imagePullPolicy: IfNotPresent
+        command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "clusterresource", "sync"]
+        volumeMounts:
+        - name: resource-templates 
+          mountPath: /etc/flyte/clusterresource/templates
         - name: config-volume
           mountPath: /etc/flyte/config
       containers:


### PR DESCRIPTION
In order to run end2end tests, FltyeAdmin needs to sync the cluster resources before starting.