### PR TITLE
The Cluster resource syncer should use the flyteadmin service account

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -1497,6 +1497,7 @@ spec:
             - mountPath: /etc/flyte/config
               name: config-volume
           restartPolicy: OnFailure
+          serviceAccountName: flyteadmin
           volumes:
           - configMap:
               name: clusterresource-template-dgc9fcm2kh

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -1053,6 +1053,7 @@ spec:
             - mountPath: /etc/flyte/config
               name: config-volume
           restartPolicy: OnFailure
+          serviceAccountName: flyteadmin
           volumes:
           - configMap:
               name: clusterresource-template-dgc9fcm2kh

--- a/kustomize/overlays/sandbox/admindeployment/cron.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/cron.yaml
@@ -9,6 +9,7 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: flyteadmin
           containers:
           - name: sync-cluster-resources
             image: docker.io/lyft/flyteadmin:v0.1.1


### PR DESCRIPTION
All control plane components should use the flyteadmin service account. Currently none was provided which works with local cluster as local cluster has default permissions. This fails on cloud sandbox deployments.