### PR TITLE
pass argument to kustomize script

### DIFF
--- a/script/kustomize.sh
+++ b/script/kustomize.sh
@@ -1,10 +1,14 @@
+#!/usr/bin/env bash
+
 set -ex
+
+DEPLOYMENT=${1:-sandbox test}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 KUSTOMIZE_IMAGE="lyft/kustomizer:v3.1.0"
 
-# flyte test
-docker run -v "${DIR}/../kustomize":/kustomize "$KUSTOMIZE_IMAGE" kustomize build overlays/test/flyte > "${DIR}/../deployment/test/flyte_generated.yaml"
-
-# flyte local
-docker run -v "${DIR}/../kustomize":/kustomize "$KUSTOMIZE_IMAGE" kustomize build overlays/sandbox/flyte > "${DIR}/../deployment/sandbox/flyte_generated.yaml"
+for deployment in ${DEPLOYMENT}; do
+    docker run -v "${DIR}/../kustomize":/kustomize "$KUSTOMIZE_IMAGE" kustomize build \
+           "overlays/${deployment}/flyte" \
+           > "${DIR}/../deployment/${deployment}/flyte_generated.yaml"
+done


### PR DESCRIPTION
By accepting an argument, users of this script would be able to specify
which deployment to build.

Internally we have customized overlay which doesn't make sense to
open source, but still we would like to utilize as much as possible from
this repo.