### PR TITLE
Fix typo in DOCKER_REGISTRY_USERNAME

### DIFF
--- a/rsts/user/getting_started/create_first.rst
+++ b/rsts/user/getting_started/create_first.rst
@@ -111,7 +111,7 @@ If you have the flyte sandbox installed on your local machine, the image will be
 
 To upload to a remote registry, use ::
 
-  DOCKER_REGISRY_USERNAME={username} DOCKER_REGISTRY_PASSWORD={pass} REGISTRY=docker.io make docker_build
+  DOCKER_REGISTRY_USERNAME={username} DOCKER_REGISTRY_PASSWORD={pass} REGISTRY=docker.io make docker_build
 
 Replace the values above with your registry username, password, and registry endpoint.
 


### PR DESCRIPTION
Trivial fix of typo in variable name.