### PR TITLE
Go mod versions

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -963,7 +963,7 @@ spec:
         - --config
         - /etc/flyte/config/flyteadmin_config.yaml
         - serve
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -1014,7 +1014,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - migrate
         - run
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -1029,7 +1029,7 @@ spec:
         - seed-projects
         - flytesnacks
         - flytetester
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -1042,7 +1042,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - clusterresource
         - sync
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -1438,7 +1438,7 @@ spec:
             - /etc/flyte/config/flyteadmin_config.yaml
             - clusterresource
             - sync
-            image: docker.io/lyft/flyteadmin:v0.2.0
+            image: docker.io/lyft/flyteadmin:v0.2.1
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -719,10 +719,9 @@ data:
     plugins:
       qubole:
         quboleTokenKey: "FLYTE_QUBOLE_CLIENT_TOKEN"
-        quboleLimit: 10
 kind: ConfigMap
 metadata:
-  name: flyte-qubole-config-t7226b4tck
+  name: flyte-qubole-config-9tcd8mk2c2
   namespace: flyte
 ---
 apiVersion: v1
@@ -964,7 +963,7 @@ spec:
         - --config
         - /etc/flyte/config/flyteadmin_config.yaml
         - serve
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -1015,7 +1014,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - migrate
         - run
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -1030,7 +1029,7 @@ spec:
         - seed-projects
         - flytesnacks
         - flytetester
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -1043,7 +1042,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - clusterresource
         - sync
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -1119,7 +1118,7 @@ spec:
       labels:
         app: flytepropeller
         app.kubernetes.io/name: flytepropeller
-        app.kubernetes.io/version: 0.1.16
+        app.kubernetes.io/version: 0.2.0
     spec:
       containers:
       - args:
@@ -1134,7 +1133,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/lyft/flytepropeller:v0.1.16
+        image: docker.io/lyft/flytepropeller:v0.2.0
         imagePullPolicy: IfNotPresent
         name: flytepropeller
         ports:
@@ -1158,7 +1157,7 @@ spec:
       serviceAccountName: flytepropeller
       volumes:
       - configMap:
-          name: flyte-qubole-config-t7226b4tck
+          name: flyte-qubole-config-9tcd8mk2c2
         name: qubole-config-volume
       - configMap:
           name: flyte-container-config-5k78b9cm42
@@ -1439,7 +1438,7 @@ spec:
             - /etc/flyte/config/flyteadmin_config.yaml
             - clusterresource
             - sync
-            image: docker.io/lyft/flyteadmin:v0.1.6
+            image: docker.io/lyft/flyteadmin:v0.2.0
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -632,7 +632,7 @@ spec:
         - --config
         - /etc/flyte/config/flyteadmin_config.yaml
         - serve
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -683,7 +683,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - migrate
         - run
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -698,7 +698,7 @@ spec:
         - seed-projects
         - flytesnacks
         - flytetester
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -711,7 +711,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - clusterresource
         - sync
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -1009,7 +1009,7 @@ spec:
             - /etc/flyte/config/flyteadmin_config.yaml
             - clusterresource
             - sync
-            image: docker.io/lyft/flyteadmin:v0.2.0
+            image: docker.io/lyft/flyteadmin:v0.2.1
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -632,7 +632,7 @@ spec:
         - --config
         - /etc/flyte/config/flyteadmin_config.yaml
         - serve
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: flyteadmin
         ports:
@@ -683,7 +683,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - migrate
         - run
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:
@@ -698,7 +698,7 @@ spec:
         - seed-projects
         - flytesnacks
         - flytetester
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: seed-projects
         volumeMounts:
@@ -711,7 +711,7 @@ spec:
         - /etc/flyte/config/flyteadmin_config.yaml
         - clusterresource
         - sync
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         name: sync-cluster-resources
         volumeMounts:
@@ -750,7 +750,7 @@ spec:
       labels:
         app: flytepropeller
         app.kubernetes.io/name: flytepropeller
-        app.kubernetes.io/version: 0.1.16
+        app.kubernetes.io/version: 0.2.0
     spec:
       containers:
       - args:
@@ -763,7 +763,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/lyft/flytepropeller:v0.1.16
+        image: docker.io/lyft/flytepropeller:v0.2.0
         imagePullPolicy: IfNotPresent
         name: flytepropeller
         ports:
@@ -1009,7 +1009,7 @@ spec:
             - /etc/flyte/config/flyteadmin_config.yaml
             - clusterresource
             - sync
-            image: docker.io/lyft/flyteadmin:v0.1.6
+            image: docker.io/lyft/flyteadmin:v0.2.0
             imagePullPolicy: IfNotPresent
             name: sync-cluster-resources
             volumeMounts:

--- a/kustomize/base/admindeployment/deployment.yaml
+++ b/kustomize/base/admindeployment/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           name: flyte-admin-config
       initContainers:
       - name: run-migrations
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "migrate", "run"]
         volumeMounts:
@@ -37,7 +37,7 @@ spec:
           mountPath: /etc/flyte/config
       containers:
       - name: flyteadmin
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "serve"]
         ports:

--- a/kustomize/base/admindeployment/deployment.yaml
+++ b/kustomize/base/admindeployment/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           name: flyte-admin-config
       initContainers:
       - name: run-migrations
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "migrate", "run"]
         volumeMounts:
@@ -37,7 +37,7 @@ spec:
           mountPath: /etc/flyte/config
       containers:
       - name: flyteadmin
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "serve"]
         ports:

--- a/kustomize/base/propeller/deployment.yaml
+++ b/kustomize/base/propeller/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: flytepropeller
         app.kubernetes.io/name: flytepropeller
-        app.kubernetes.io/version: 0.1.16
+        app.kubernetes.io/version: 0.2.0
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
@@ -31,7 +31,7 @@ spec:
           name: flyte-plugin-config
       containers:
       - name: flytepropeller
-        image: docker.io/lyft/flytepropeller:v0.1.16
+        image: docker.io/lyft/flytepropeller:v0.2.0
         command:
         - flytepropeller
         args:

--- a/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
@@ -17,7 +17,7 @@ spec:
           'until pg_isready -h postgres -p 5432;
           do echo waiting for database; sleep 2; done;']
       - name: run-migrations
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml",
                   "migrate", "run"]
@@ -25,7 +25,7 @@ spec:
         - name: config-volume
           mountPath: /etc/flyte/config
       - name: seed-projects
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml",
                   "migrate", "seed-projects", "flytesnacks", "flytetester"]
@@ -33,7 +33,7 @@ spec:
         - name: config-volume
           mountPath: /etc/flyte/config
       - name: sync-cluster-resources
-        image: docker.io/lyft/flyteadmin:v0.1.6
+        image: docker.io/lyft/flyteadmin:v0.2.0
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "clusterresource", "sync"]
         volumeMounts:

--- a/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
@@ -17,7 +17,7 @@ spec:
           'until pg_isready -h postgres -p 5432;
           do echo waiting for database; sleep 2; done;']
       - name: run-migrations
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml",
                   "migrate", "run"]
@@ -25,7 +25,7 @@ spec:
         - name: config-volume
           mountPath: /etc/flyte/config
       - name: seed-projects
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml",
                   "migrate", "seed-projects", "flytesnacks", "flytetester"]
@@ -33,7 +33,7 @@ spec:
         - name: config-volume
           mountPath: /etc/flyte/config
       - name: sync-cluster-resources
-        image: docker.io/lyft/flyteadmin:v0.2.0
+        image: docker.io/lyft/flyteadmin:v0.2.1
         imagePullPolicy: IfNotPresent
         command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "clusterresource", "sync"]
         volumeMounts:

--- a/kustomize/overlays/sandbox/admindeployment/cron.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/cron.yaml
@@ -12,7 +12,7 @@ spec:
           serviceAccountName: flyteadmin
           containers:
           - name: sync-cluster-resources
-            image: docker.io/lyft/flyteadmin:v0.1.6
+            image: docker.io/lyft/flyteadmin:v0.2.0
             imagePullPolicy: IfNotPresent
             command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "clusterresource", "sync"]
             volumeMounts:

--- a/kustomize/overlays/sandbox/admindeployment/cron.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/cron.yaml
@@ -12,7 +12,7 @@ spec:
           serviceAccountName: flyteadmin
           containers:
           - name: sync-cluster-resources
-            image: docker.io/lyft/flyteadmin:v0.2.0
+            image: docker.io/lyft/flyteadmin:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "clusterresource", "sync"]
             volumeMounts:

--- a/kustomize/overlays/sandbox/propeller/plugins/qubole/config.yaml
+++ b/kustomize/overlays/sandbox/propeller/plugins/qubole/config.yaml
@@ -1,4 +1,3 @@
 plugins:
   qubole:
     quboleTokenKey: "FLYTE_QUBOLE_CLIENT_TOKEN"
-    quboleLimit: 10


### PR DESCRIPTION
Admin and propeller to use versions that use go mod for dependency management.  There was a bug in Admin that was fixed which is why we've gone one version beyond.

See related issue: https://github.com/lyft/flyte/issues/129

Also,
* Removing a broken key in propeller config that's been removed