### PR TITLE
upgrade to latest tag of datacatalog

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -889,7 +889,7 @@ spec:
         - --config
         - /etc/datacatalog/config/datacatalog_config.yaml
         - serve
-        image: docker.io/lyft/datacatalog:v0.1.1
+        image: docker.io/lyft/datacatalog:v0.1.2
         imagePullPolicy: IfNotPresent
         name: datacatalog
         ports:
@@ -921,7 +921,7 @@ spec:
         - /etc/datacatalog/config/datacatalog_config.yaml
         - migrate
         - run
-        image: docker.io/lyft/datacatalog:v0.1.1
+        image: docker.io/lyft/datacatalog:v0.1.2
         imagePullPolicy: IfNotPresent
         name: run-migrations
         volumeMounts:

--- a/kustomize/base/datacatalog/deployment.yaml
+++ b/kustomize/base/datacatalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           name: datacatalog-config
       initContainers:
       - name: run-migrations
-        image: docker.io/lyft/datacatalog:v0.1.1
+        image: docker.io/lyft/datacatalog:v0.1.2
         imagePullPolicy: IfNotPresent
         command: ["datacatalog", "--logtostderr", "--config", "/etc/datacatalog/config/datacatalog_config.yaml", "migrate", "run"]
         volumeMounts:
@@ -36,7 +36,7 @@ spec:
           mountPath: /etc/datacatalog/config
       containers:
       - name: datacatalog
-        image: docker.io/lyft/datacatalog:v0.1.1
+        image: docker.io/lyft/datacatalog:v0.1.2
         imagePullPolicy: IfNotPresent
         command: ["datacatalog", "--logtostderr", "--config", "/etc/datacatalog/config/datacatalog_config.yaml", "serve"]
         ports:


### PR DESCRIPTION
v0.1.1 is quite old and this PR upgrades to latest tag according to https://hub.docker.com/r/lyft/datacatalog/tags