### PR TITLE
check generated file as part of GitHub Workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
         go-version: [1.10]
     steps:
     - uses: actions/checkout@v1
+    - name: Kustomize and diff
+      run: DELTA_CHECK=true make kustomize
     - name: Set up Go@${{ matrix.go-version }}
       uses: actions/setup-go@v1
       with:

--- a/script/kustomize.sh
+++ b/script/kustomize.sh
@@ -12,3 +12,19 @@ for deployment in ${DEPLOYMENT}; do
            "overlays/${deployment}/flyte" \
            > "${DIR}/../deployment/${deployment}/flyte_generated.yaml"
 done
+
+# This section is used by GitHub workflow to ensure that the generation step was run
+if [ -n "$DELTA_CHECK" ]; then
+  DIRTY=$(git status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "FAILED: kustomize code updated without commiting generated code."
+    echo "Ensure make kustomize has run and all changes are committed."
+    DIFF=$(git diff)
+    echo "diff detected: $DIFF"
+    DIFF=$(git diff --name-only)
+    echo "files different: $DIFF"
+    exit 1
+  else
+    echo "SUCCESS: Generated code is up to date."
+  fi
+fi


### PR DESCRIPTION
## Description

This PR configures a step of GitHub Workflow to ensure that in case of modification of kustomize code, `make kustomize` was executed and the newly generated `flyte_generated.yaml` was added as a part of the commit.

This PR is inspired by https://github.com/lyft/flyteidl/blob/master/generate_protos.sh#L58

## Motivation

It is very likely that a new contributor of this repo updated some kustomize file but didn't do `make kustomize`. Having an automated step telling what is missing would be useful.


## How did I test it

* https://github.com/lyft/flyte/pull/200/checks?check_run_id=496295498 as a successful workflow execution
* https://github.com/lyft/flyte/pull/200/checks?check_run_id=496307946 as a failed one
