### PR TITLE
K8s crons have issues on docker-for-mac deployments.

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -600,10 +600,10 @@ data:
         name: domain
     cluster_resources:
       templatePath: "/etc/flyte/clusterresource/templates"
-      refresh: 5m
+      refresh: 10s
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-4k466cfctf
+  name: flyte-admin-config-h889md4bc8
   namespace: flyte
 ---
 apiVersion: v1
@@ -965,6 +965,21 @@ spec:
       containers:
       - command:
         - flyteadmin
+        - --logger.mute
+        - --config
+        - /etc/flyte/config/flyteadmin_config.yaml
+        - clusterresource
+        - run
+        image: docker.io/lyft/flyteadmin:v0.2.4
+        imagePullPolicy: IfNotPresent
+        name: run-cluster-resources
+        volumeMounts:
+        - mountPath: /etc/flyte/clusterresource/templates
+          name: resource-templates
+        - mountPath: /etc/flyte/config
+          name: config-volume
+      - command:
+        - flyteadmin
         - --logtostderr
         - --config
         - /etc/flyte/config/flyteadmin_config.yaml
@@ -1042,21 +1057,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
-      - command:
-        - flyteadmin
-        - --logtostderr
-        - --config
-        - /etc/flyte/config/flyteadmin_config.yaml
-        - clusterresource
-        - sync
-        image: docker.io/lyft/flyteadmin:v0.2.4
-        imagePullPolicy: IfNotPresent
-        name: sync-cluster-resources
-        volumeMounts:
-        - mountPath: /etc/flyte/clusterresource/templates
-          name: resource-templates
-        - mountPath: /etc/flyte/config
-          name: config-volume
       serviceAccountName: flyteadmin
       volumes:
       - configMap:
@@ -1065,7 +1065,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-4k466cfctf
+          name: flyte-admin-config-h889md4bc8
         name: config-volume
 ---
 apiVersion: apps/v1
@@ -1462,7 +1462,7 @@ spec:
               name: clusterresource-template-dgc9fcm2kh
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-4k466cfctf
+              name: flyte-admin-config-h889md4bc8
             name: config-volume
   schedule: '*/1 * * * *'
 ---

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -439,10 +439,10 @@ data:
         name: domain
     cluster_resources:
       templatePath: "/etc/flyte/clusterresource/templates"
-      refresh: 5m
+      refresh: 10s
 kind: ConfigMap
 metadata:
-  name: flyte-admin-config-4k466cfctf
+  name: flyte-admin-config-h889md4bc8
   namespace: flyte
 ---
 apiVersion: v1
@@ -632,6 +632,21 @@ spec:
       containers:
       - command:
         - flyteadmin
+        - --logger.mute
+        - --config
+        - /etc/flyte/config/flyteadmin_config.yaml
+        - clusterresource
+        - run
+        image: docker.io/lyft/flyteadmin:v0.2.4
+        imagePullPolicy: IfNotPresent
+        name: run-cluster-resources
+        volumeMounts:
+        - mountPath: /etc/flyte/clusterresource/templates
+          name: resource-templates
+        - mountPath: /etc/flyte/config
+          name: config-volume
+      - command:
+        - flyteadmin
         - --logtostderr
         - --config
         - /etc/flyte/config/flyteadmin_config.yaml
@@ -709,21 +724,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/flyte/config
           name: config-volume
-      - command:
-        - flyteadmin
-        - --logtostderr
-        - --config
-        - /etc/flyte/config/flyteadmin_config.yaml
-        - clusterresource
-        - sync
-        image: docker.io/lyft/flyteadmin:v0.2.4
-        imagePullPolicy: IfNotPresent
-        name: sync-cluster-resources
-        volumeMounts:
-        - mountPath: /etc/flyte/clusterresource/templates
-          name: resource-templates
-        - mountPath: /etc/flyte/config
-          name: config-volume
       serviceAccountName: flyteadmin
       volumes:
       - configMap:
@@ -732,7 +732,7 @@ spec:
       - emptyDir: {}
         name: shared-data
       - configMap:
-          name: flyte-admin-config-4k466cfctf
+          name: flyte-admin-config-h889md4bc8
         name: config-volume
 ---
 apiVersion: apps/v1
@@ -1029,7 +1029,7 @@ spec:
               name: clusterresource-template-dgc9fcm2kh
             name: resource-templates
           - configMap:
-              name: flyte-admin-config-4k466cfctf
+              name: flyte-admin-config-h889md4bc8
             name: config-volume
   schedule: '*/1 * * * *'
 ---

--- a/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/admindeployment.yaml
@@ -32,16 +32,22 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/flyte/config
-      - name: sync-cluster-resources
+      containers:
+      - command:
+        - flyteadmin
+        - --logger.mute
+        - --config
+        - /etc/flyte/config/flyteadmin_config.yaml
+        - clusterresource
+        - run
         image: docker.io/lyft/flyteadmin:v0.2.4
         imagePullPolicy: IfNotPresent
-        command: ["flyteadmin", "--logtostderr", "--config", "/etc/flyte/config/flyteadmin_config.yaml", "clusterresource", "sync"]
+        name: run-cluster-resources
         volumeMounts:
-        - name: resource-templates 
+        - name: resource-templates
           mountPath: /etc/flyte/clusterresource/templates
         - name: config-volume
           mountPath: /etc/flyte/config
-      containers:
       - name: flyteadmin
         resources:
           limits:

--- a/kustomize/overlays/sandbox/admindeployment/flyteadmin_config.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/flyteadmin_config.yaml
@@ -62,4 +62,4 @@ domains:
     name: domain
 cluster_resources:
   templatePath: "/etc/flyte/clusterresource/templates"
-  refresh: 5m
+  refresh: 10s


### PR DESCRIPTION
K8s crons have issues on docker-for-mac deployments. This moves cluster resource syncing from cron to loop. It also disables the logging for this function, since the logging is too verbose and quickly runs the node out of disk space.

This PR resolves https://github.com/lyft/flyte/issues/162

I've created an additional ticket to resolve verbose logging 

