### PR TITLE
SparkOperator: Run certs as an init-container

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -1405,6 +1405,15 @@ spec:
         volumeMounts:
         - mountPath: /etc/webhook-certs
           name: webhook-certs
+      initContainers:
+      - command:
+        - /usr/bin/gencerts.sh
+        - --namespace
+        - sparkoperator
+        - -p
+        image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
+        imagePullPolicy: IfNotPresent
+        name: main
       serviceAccountName: sparkoperator
       volumes:
       - name: webhook-certs
@@ -1507,34 +1516,6 @@ spec:
               name: flyte-admin-config-dtcg25hb22
             name: config-volume
   schedule: '*/1 * * * *'
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  labels:
-    app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v2.4.0-v1beta1
-  name: sparkoperator-init
-  namespace: sparkoperator
-spec:
-  backoffLimit: 3
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: sparkoperator
-        app.kubernetes.io/version: v2.4.0-v1beta1
-    spec:
-      containers:
-      - command:
-        - /usr/bin/gencerts.sh
-        - --namespace
-        - sparkoperator
-        - -p
-        image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
-        imagePullPolicy: IfNotPresent
-        name: main
-      restartPolicy: Never
-      serviceAccountName: sparkoperator
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -1405,15 +1405,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/webhook-certs
           name: webhook-certs
-      initContainers:
-      - command:
-        - /usr/bin/gencerts.sh
-        - --namespace
-        - sparkoperator
-        - -p
-        image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
-        imagePullPolicy: IfNotPresent
-        name: main
       serviceAccountName: sparkoperator
       volumes:
       - name: webhook-certs
@@ -1516,6 +1507,34 @@ spec:
               name: flyte-admin-config-dtcg25hb22
             name: config-volume
   schedule: '*/1 * * * *'
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/name: sparkoperator
+    app.kubernetes.io/version: v2.4.0-v1beta1
+  name: sparkoperator-init
+  namespace: sparkoperator
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sparkoperator
+        app.kubernetes.io/version: v2.4.0-v1beta1
+    spec:
+      containers:
+      - command:
+        - /usr/bin/gencerts.sh
+        - --namespace
+        - sparkoperator
+        - -p
+        image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
+        imagePullPolicy: IfNotPresent
+        name: main
+      restartPolicy: Never
+      serviceAccountName: sparkoperator
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/kustomize/base/operators/spark/deployment.yaml
+++ b/kustomize/base/operators/spark/deployment.yaml
@@ -29,6 +29,11 @@ spec:
         - name: webhook-certs
           secret:
             secretName: spark-webhook-certs
+      initContainers:
+      - name: main
+        image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/gencerts.sh","--namespace", "sparkoperator", "-p"]
       containers:
       - name: sparkoperator-unknown
         image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0

--- a/kustomize/base/operators/spark/deployment.yaml
+++ b/kustomize/base/operators/spark/deployment.yaml
@@ -1,3 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sparkoperator-init
+  namespace: sparkoperator
+  labels:
+    app.kubernetes.io/name: sparkoperator
+    app.kubernetes.io/version: v2.4.0-v1beta1
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sparkoperator
+        app.kubernetes.io/version: v2.4.0-v1beta1
+    spec:
+      serviceAccountName: sparkoperator
+      restartPolicy: Never
+      containers:
+        - name: main
+          image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/bin/gencerts.sh","--namespace", "sparkoperator", "-p"]
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,11 +53,6 @@ spec:
         - name: webhook-certs
           secret:
             secretName: spark-webhook-certs
-      initContainers:
-      - name: main
-        image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
-        imagePullPolicy: IfNotPresent
-        command: ["/usr/bin/gencerts.sh","--namespace", "sparkoperator", "-p"]
       containers:
       - name: sparkoperator-unknown
         image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0

--- a/kustomize/base/operators/spark/webhook.yaml
+++ b/kustomize/base/operators/spark/webhook.yaml
@@ -1,27 +1,3 @@
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: sparkoperator-init
-  namespace: sparkoperator
-  labels:
-    app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: v2.4.0-v1beta1
-spec:
-  backoffLimit: 3
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: sparkoperator
-        app.kubernetes.io/version: v2.4.0-v1beta1
-    spec:
-      serviceAccountName: sparkoperator
-      restartPolicy: Never
-      containers:
-        - name: main
-          image: gcr.io/spark-operator/spark-operator:v2.4.0-v1beta1-0.9.0
-          imagePullPolicy: IfNotPresent
-          command: ["/usr/bin/gencerts.sh","--namespace", "sparkoperator", "-p"]
----
 kind: Service
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Kustomize doesn't have a way to honor dependencies between the SparkOperator init-job which generates certs required by the SparkOperator deployment. 
This runs the init-job as an init-container on the deployment and mitigates this issue.