### PR TITLE
Expose sandbox node ports for Minio and Postgres

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -840,6 +840,22 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: minio
+  name: minio-direct
+  namespace: flyte
+spec:
+  ports:
+  - nodePort: 30082
+    port: 9000
+    protocol: TCP
+  selector:
+    app: minio
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: postgres
   namespace: flyte
 spec:
@@ -847,6 +863,22 @@ spec:
   - port: 5432
   selector:
     app: postgres
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postgres
+  name: postgres-direct
+  namespace: flyte
+spec:
+  ports:
+  - nodePort: 30083
+    port: 5432
+    protocol: TCP
+  selector:
+    app: postgres
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -846,7 +846,7 @@ metadata:
   namespace: flyte
 spec:
   ports:
-  - nodePort: 30082
+  - nodePort: 30084
     port: 9000
     protocol: TCP
   selector:

--- a/kustomize/base/admindeployment/service.yaml
+++ b/kustomize/base/admindeployment/service.yaml
@@ -22,4 +22,3 @@ spec:
     protocol: TCP
     port: 81
     targetPort: 8089
-

--- a/kustomize/overlays/eks/datacatalog/datacatalog.yaml
+++ b/kustomize/overlays/eks/datacatalog/datacatalog.yaml
@@ -19,4 +19,3 @@ kind: Service
 metadata:
   name: datacatalog 
   namespace: flyte
-

--- a/kustomize/overlays/eks/datacatalog/service.yaml
+++ b/kustomize/overlays/eks/datacatalog/service.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: flyte
 spec:
   type: NodePort
-

--- a/kustomize/overlays/sandbox/dependencies/kustomization.yaml
+++ b/kustomize/overlays/sandbox/dependencies/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+  - ../dependencies/service.yaml

--- a/kustomize/overlays/sandbox/dependencies/service.yaml
+++ b/kustomize/overlays/sandbox/dependencies/service.yaml
@@ -1,23 +1,7 @@
 # For docker-desktop at least, the range of valid ports is 30000-32767, which is why we're constrained to these
-# odd port numbers. Since the base ingress runs on 30081, these just continue from there.
+# odd port numbers. Since the base ingress runs on 30081, the K8s dashboard runs on 30082, these just continue from there.
 # These nodeports are exposed to save contributors the trouble of port forwarding when running locally.
 
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: minio
-  name: minio-direct
-  namespace: flyte
-spec:
-  ports:
-  - nodePort: 30082
-    port: 9000
-    protocol: TCP
-  selector:
-    app: minio
-  type: NodePort
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,4 +16,20 @@ spec:
     protocol: TCP
   selector:
     app: postgres
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: minio
+  name: minio-direct
+  namespace: flyte
+spec:
+  ports:
+  - nodePort: 30084
+    port: 9000
+    protocol: TCP
+  selector:
+    app: minio
   type: NodePort

--- a/kustomize/overlays/sandbox/dependencies/service.yaml
+++ b/kustomize/overlays/sandbox/dependencies/service.yaml
@@ -1,0 +1,35 @@
+# For docker-desktop at least, the range of valid ports is 30000-32767, which is why we're constrained to these
+# odd port numbers. Since the base ingress runs on 30081, these just continue from there.
+# These nodeports are exposed to save contributors the trouble of port forwarding when running locally.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: minio
+  name: minio-direct
+  namespace: flyte
+spec:
+  ports:
+  - nodePort: 30082
+    port: 9000
+    protocol: TCP
+  selector:
+    app: minio
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postgres
+  name: postgres-direct
+  namespace: flyte
+spec:
+  ports:
+  - nodePort: 30083
+    port: 5432
+    protocol: TCP
+  selector:
+    app: postgres
+  type: NodePort

--- a/kustomize/overlays/sandbox/flyte/kustomization.yaml
+++ b/kustomize/overlays/sandbox/flyte/kustomization.yaml
@@ -17,3 +17,6 @@ bases:
 - ../../../base/adminserviceaccount
 - ../propeller
 - ../redis
+
+# dependencies
+- ../dependencies/service.yaml

--- a/kustomize/overlays/sandbox/flyte/kustomization.yaml
+++ b/kustomize/overlays/sandbox/flyte/kustomization.yaml
@@ -19,4 +19,4 @@ bases:
 - ../redis
 
 # dependencies
-- ../dependencies/service.yaml
+- ../dependencies


### PR DESCRIPTION
When developing Flyte, it is necessary often to run both Propeller and Admin from the contributor's laptop (from Goland for instance).  In these cases, contributors currently need to port forward each of Minio and Postgres in order to do so.

This exposes 30083 for the sandbox Postgres instance and 30084 for Minio, thereby making port forwarding no longer necessary.
