### PR TITLE
Add flyte-data-config ConfigMap to sandbox kustomization

### DIFF
--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -496,9 +496,28 @@ data:
   ab_project-resource-quota.yaml: "apiVersion: v1\nkind: ResourceQuota\nmetadata:\n
     \ name: project-quota\n  namespace: {{ namespace }} \nspec:\n  hard:\n    limits.cpu:
     {{ projectQuotaCpu }} \n    limits.memory: {{ projectQuotaMemory }}\n\n"
+  ac_project-copilot-dataconfig.yaml: |
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: flyte-data-config
+      namespace: {{ namespace }}
+    data:
+      config.yaml: |
+        storage:
+          connection:
+            access-key: minio
+            auth-type: accesskey
+            disable-ssl: true
+            endpoint: http://minio.flyte.svc.cluster.local:9000
+            region: us-east-1
+            secret-key: miniostorage
+          type: minio
+          container: my-s3-bucket
+          enable-multicontainer: true
 kind: ConfigMap
 metadata:
-  name: clusterresource-template-m2kccc465f
+  name: clusterresource-template-9mbg4b2fhc
   namespace: flyte
 ---
 apiVersion: v1
@@ -1129,7 +1148,7 @@ spec:
       serviceAccountName: flyteadmin
       volumes:
       - configMap:
-          name: clusterresource-template-m2kccc465f
+          name: clusterresource-template-9mbg4b2fhc
         name: resource-templates
       - emptyDir: {}
         name: shared-data
@@ -1538,7 +1557,7 @@ spec:
           serviceAccountName: flyteadmin
           volumes:
           - configMap:
-              name: clusterresource-template-m2kccc465f
+              name: clusterresource-template-9mbg4b2fhc
             name: resource-templates
           - configMap:
               name: flyte-admin-config-dtcg25hb22

--- a/deployment/test/flyte_generated.yaml
+++ b/deployment/test/flyte_generated.yaml
@@ -370,9 +370,28 @@ data:
   ab_project-resource-quota.yaml: "apiVersion: v1\nkind: ResourceQuota\nmetadata:\n
     \ name: project-quota\n  namespace: {{ namespace }} \nspec:\n  hard:\n    limits.cpu:
     {{ projectQuotaCpu }} \n    limits.memory: {{ projectQuotaMemory }}\n\n"
+  ac_project-copilot-dataconfig.yaml: |
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: flyte-data-config
+      namespace: {{ namespace }}
+    data:
+      config.yaml: |
+        storage:
+          connection:
+            access-key: minio
+            auth-type: accesskey
+            disable-ssl: true
+            endpoint: http://minio.flyte.svc.cluster.local:9000
+            region: us-east-1
+            secret-key: miniostorage
+          type: minio
+          container: my-s3-bucket
+          enable-multicontainer: true
 kind: ConfigMap
 metadata:
-  name: clusterresource-template-m2kccc465f
+  name: clusterresource-template-9mbg4b2fhc
   namespace: flyte
 ---
 apiVersion: v1
@@ -750,7 +769,7 @@ spec:
       serviceAccountName: flyteadmin
       volumes:
       - configMap:
-          name: clusterresource-template-m2kccc465f
+          name: clusterresource-template-9mbg4b2fhc
         name: resource-templates
       - emptyDir: {}
         name: shared-data
@@ -1049,7 +1068,7 @@ spec:
           serviceAccountName: flyteadmin
           volumes:
           - configMap:
-              name: clusterresource-template-m2kccc465f
+              name: clusterresource-template-9mbg4b2fhc
             name: resource-templates
           - configMap:
               name: flyte-admin-config-dtcg25hb22

--- a/kustomize/overlays/sandbox/admindeployment/kustomization.yaml
+++ b/kustomize/overlays/sandbox/admindeployment/kustomization.yaml
@@ -17,6 +17,7 @@ configMapGenerator:
 # Files are read in alphabetical order. To ensure that we create the namespace first, prefix the file name with "aa".
     - clusterresource-templates/aa_namespace.yaml
     - clusterresource-templates/ab_project-resource-quota.yaml
+    - clusterresource-templates/ac_project-copilot-dataconfig.yaml
 
 patches:
 - admindeployment.yaml


### PR DESCRIPTION
I've been playing with raw containers and this seemed to be missing piece to run the `flytecopilot` container successfully.