### PR TITLE
Update Spark CRDs to support 1.18+

### DIFF
--- a/deployment/eks/flyte_generated.yaml
+++ b/deployment/eks/flyte_generated.yaml
@@ -828,6 +828,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -1457,6 +1458,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2361,6 +2363,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2886,6 +2889,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -4571,6 +4575,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -5200,6 +5205,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -6104,6 +6110,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -6629,6 +6636,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deployment/gcp/flyte_generated.yaml
+++ b/deployment/gcp/flyte_generated.yaml
@@ -828,6 +828,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -1457,6 +1458,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2361,6 +2363,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2886,6 +2889,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -4571,6 +4575,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -5200,6 +5205,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -6104,6 +6110,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -6629,6 +6636,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deployment/sandbox/flyte_generated.yaml
+++ b/deployment/sandbox/flyte_generated.yaml
@@ -963,6 +963,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -1592,6 +1593,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2496,6 +2498,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -3021,6 +3024,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -4706,6 +4710,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -5335,6 +5340,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -6239,6 +6245,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -6764,6 +6771,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/kustomize/base/operators/spark/scheduledsparkapplications-crd.yaml
+++ b/kustomize/base/operators/spark/scheduledsparkapplications-crd.yaml
@@ -767,6 +767,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -1396,6 +1397,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2300,6 +2302,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:
@@ -2825,6 +2828,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:

--- a/kustomize/base/operators/spark/sparkapplications-crd.yaml
+++ b/kustomize/base/operators/spark/sparkapplications-crd.yaml
@@ -753,6 +753,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -1382,6 +1383,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -2286,6 +2288,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -2811,6 +2814,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:


### PR DESCRIPTION
Spark resource definition currently fail on 1.18+ . Ref: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1065 

Cherry-picked https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/commit/5b2fe9218108baa6456eb3472196d5eb55b41efd to fix the same 